### PR TITLE
Replace WebAssembly module with a component.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ node_modules/
 dist/
 .parcel-cache/
 yarn-error.log
-src/graph_bg.wasm
+src/graph.core.wasm
+src/graph.d.ts
 src/graph.js

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "rust-analyzer.server.extraEnv": { "CARGO": "cargo-component" }
+}

--- a/Makefile
+++ b/Makefile
@@ -3,25 +3,19 @@ ESLINT := $(MODULES)/eslint
 PARCEL := $(MODULES)/parcel
 CARGO := cargo
 YARN := yarn
-WASM_BINDGEN := wasm-bindgen
 ENTRY_POINT := src/index.html
-WASM_OPT := wasm-opt
-WASM_STRIP := wasm-strip
+WIT_BINDGEN := wit-bindgen
 
 help:
 	@grep -E '^[a-zA-Z\._-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
-build: ## builds the graph wasm module
-	@$(CARGO) build --release --target wasm32-unknown-unknown -p graph
+build: ## builds the graph component
+	@$(CARGO) component build --release -p graph
 
-bindgen: build ## generates bindings for the graph wasm module
-	@$(WASM_BINDGEN) --target web target/wasm32-unknown-unknown/release/graph.wasm --out-dir src --no-typescript
+bindgen: build ## generates bindings for the graph component
+	@$(WIT_BINDGEN) host js target/wasm32-unknown-unknown/release/graph.wasm --tla-compat --out-dir src
 
-opt: bindgen # optimizes the graph wasm module
-	@$(WASM_OPT) -Os src/graph_bg.wasm -o src/graph_bg.wasm
-	@$(WASM_STRIP) src/graph_bg.wasm
-
-bundle: opt ## bundles the application
+bundle: bindgen ## bundles the application
 	@$(PARCEL) build $(ENTRY_POINT)
 
 format: ## formats source code
@@ -32,11 +26,13 @@ test: ## runs tests
 	@$(CARGO) test
 
 lint: ## runs linting
-	@$(CARGO) clippy --release --target wasm32-unknown-unknown
+	@$(CARGO) component clippy --release --target wasm32-unknown-unknown
 	@$(ESLINT) src
 
 run: bindgen ## runs development
 	@$(PARCEL) $(ENTRY_POINT) -p 3000
 
-setup: ## installs dependencies
+setup: ## installs build dependencies
 	@$(YARN)
+	@$(CARGO) install --git https://github.com/bytecodealliance/wit-bindgen wit-bindgen-cli
+	@$(CARGO) install --git https://github.com/bytecodealliance/cargo-component

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ CARGO := cargo
 YARN := yarn
 ENTRY_POINT := src/index.html
 WIT_BINDGEN := wit-bindgen
+WASM_OPT := wasm-opt
+WASM_STRIP := wasm-strip
 
 help:
 	@grep -E '^[a-zA-Z\._-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -15,7 +17,11 @@ build: ## builds the graph component
 bindgen: build ## generates bindings for the graph component
 	@$(WIT_BINDGEN) host js target/wasm32-unknown-unknown/release/graph.wasm --tla-compat --out-dir src
 
-bundle: bindgen ## bundles the application
+opt: bindgen # optimizes the graph wasm module
+	@$(WASM_OPT) -Os src/graph.core.wasm -o src/graph.core.wasm
+	@$(WASM_STRIP) src/graph.core.wasm
+
+bundle: opt ## bundles the application
 	@$(PARCEL) build $(ENTRY_POINT)
 
 format: ## formats source code

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ from other WebAssembly components.
 To build this project, the following tools must be installed locally:
 
 - [The latest stable Rust toolchain](https://www.rust-lang.org/tools/install)
-- [wasm-bindgen CLI](https://rustwasm.github.io/docs/wasm-bindgen/reference/cli.html)
 - [Yarn](https://yarnpkg.com/getting-started/install)
 - [Make](https://www.gnu.org/software/make/)
 
@@ -23,6 +22,9 @@ To install the dependencies of the project, run the following command:
 ```sh
 $ make setup
 ```
+
+This will also install the `wit-bindgen` and `cargo component` command line tools
+(if not already installed).
 
 ### Running Locally
 
@@ -81,7 +83,7 @@ This will create an instance of the component that can be connected to other ins
 ### Anatomy of an Instance
 
 Each instance of a component has a set of imports and exports. Exports and imports can be connected
-by dragging a connection between the circles that represent them.
+by dragging a connection between the circles and squares that represent them.
 
 An example instance:
 
@@ -98,7 +100,7 @@ Finally, the checkbox in the upper left corner can be used to export the instanc
 ### Connecting Instances
 
 To connect two instances, drag a connection from the circle of an export on one instance to the
-circle of a matching import on another instance.
+square of a matching import on another instance.
 
 The names do not need to match, but the types of the items must be compatible with one another.
 

--- a/crates/graph/Cargo.toml
+++ b/crates/graph/Cargo.toml
@@ -10,11 +10,13 @@ crate-type = ["cdylib"]
 [dependencies]
 anyhow = "1.0.66"
 once_cell = "1.15.0"
-serde = "1.0.145"
-serde_json = "1.0.87"
-wasm-bindgen = "0.2.83"
 wasmparser = { git = "https://github.com/bytecodealliance/wasm-tools", rev = "cdba43d" }
 wit-component = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "e1b85f2" }
 wasm-compose = { git = "https://github.com/bytecodealliance/wasm-tools", rev = "cdba43d" }
 wat = "1.0.49"
-serde-wasm-bindgen = "0.4.5"
+
+[package.metadata.component]
+direct-export = "interface"
+
+[package.metadata.component.exports]
+interface = "interface.wit"

--- a/crates/graph/interface.wit
+++ b/crates/graph/interface.wit
@@ -1,0 +1,85 @@
+/// Represents a kind of import or export in a WebAssembly component.
+enum item-kind {
+    /// The item is a core module.
+    module,
+    /// The item is a function.
+    function,
+    /// The item is a value.
+    value,
+    /// The item is a type.
+    %type,
+    /// The item is an instance.
+    instance,
+    /// The item is a component.
+    component,
+}
+
+/// Represents an import in a WebAssembly component.
+record import {
+    /// The import name.
+    name: string,
+    /// The import kind.
+    kind: item-kind,
+}
+
+/// Represents an export in a WebAssembly component.
+record export {
+    /// The export name.
+    name: string,
+    /// The export kind.
+    kind: item-kind,
+}
+
+/// Represents a WebAssembly component.
+record component {
+    /// The id of the component in the graph/
+    id: component-id,
+    /// The name of the component.
+    name: string,
+    /// The imports of the component.
+    imports: list<import>,
+    /// The exports of the component.
+    exports: list<export>,
+    /// The interface definition of the component.
+    %interface: option<string>
+}
+
+/// Represents options for encoding the graph.
+record encode-options {
+    /// Whether or not to define components in the output.
+    define-components: bool,
+    /// The instance to export from the output.
+    export: option<instance-id>,
+    /// Whether or not to validate the output.
+    validate: bool,
+}
+
+/// Represents a component identifier in the graph.
+type component-id = u32
+
+/// Represents an instance identifier in the graph.
+type instance-id = u32
+
+/// Adds a component to the graph.
+add-component: func(name: string, bytes: list<u8>) -> result<component, string>
+
+/// Instantiates a component in the graph.
+instantiate-component: func(id: component-id) -> result<instance-id, string>
+
+/// Connects two instances in the graph.
+connect-instances: func(source: instance-id, source-export: option<u32>, target: instance-id, target-import: u32) -> result<_, string>
+
+/// Remove a component from the graph.
+remove-component: func(id: component-id)
+
+/// Remove an instance from the graph.
+remove-instance: func(id: instance-id)
+
+/// Disconnect connected instances in the graph.
+disconnect-instances: func(source: instance-id, target: instance-id, target-import: u32) -> result<_, string>
+
+/// Print the current graph state.
+print-graph: func() -> string
+
+/// Encode the current graph state as a new component.
+encode-graph: func(options: encode-options) -> result<list<u8>, string>

--- a/crates/graph/src/lib.rs
+++ b/crates/graph/src/lib.rs
@@ -1,201 +1,139 @@
 use anyhow::Result;
+use bindings::interface::{
+    Component, ComponentId, EncodeOptions, Export, Import, InstanceId, Interface, ItemKind,
+};
 use once_cell::sync::Lazy;
-use serde::{ser::SerializeMap, ser::SerializeSeq, Serialize, Serializer};
 use std::sync::Mutex;
-use wasm_bindgen::prelude::*;
-use wasm_compose::graph::{Component, ComponentId, CompositionGraph, EncodeOptions};
+use wasm_compose::graph::CompositionGraph;
 use wasmparser::{ComponentExternalKind, ComponentTypeRef};
 use wit_component::{decode_component_interfaces, InterfacePrinter};
 
 static GRAPH: Lazy<Mutex<CompositionGraph>> = Lazy::new(Default::default);
 
-struct ImportsSerializer<'a>(&'a Component<'a>);
+struct GraphComponent;
 
-impl<'a> Serialize for ImportsSerializer<'a> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        struct ImportSerializer<'a>(&'a str, ComponentTypeRef);
-        impl<'a> Serialize for ImportSerializer<'a> {
-            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-            where
-                S: Serializer,
-            {
-                let mut map = serializer.serialize_map(Some(2))?;
-                map.serialize_entry("name", self.0)?;
-                map.serialize_entry(
-                    "kind",
-                    match self.1 {
-                        ComponentTypeRef::Module(_) => "module",
-                        ComponentTypeRef::Func(_) => "function",
-                        ComponentTypeRef::Value(_) => "value",
-                        ComponentTypeRef::Type(_, _) => "type",
-                        ComponentTypeRef::Instance(_) => "instance",
-                        ComponentTypeRef::Component(_) => "component",
-                    },
-                )?;
-                map.end()
-            }
-        }
+impl Interface for GraphComponent {
+    fn add_component(name: String, bytes: Vec<u8>) -> Result<Component, String> {
+        let component = wasm_compose::graph::Component::from_bytes(name, bytes)
+            .map_err(|e| format!("{e:#}"))?;
 
-        let imports = self.0.imports();
-        let mut seq = serializer.serialize_seq(Some(imports.len()))?;
-        for (_, name, kind) in imports {
-            seq.serialize_element(&ImportSerializer(name, kind))?;
-        }
+        let mut graph = GRAPH.lock().unwrap();
 
-        seq.end()
-    }
-}
+        let id = graph
+            .add_component(component)
+            .map_err(|e| format!("{e:#}"))?;
 
-struct ExportsSerializer<'a>(&'a Component<'a>);
-
-impl<'a> Serialize for ExportsSerializer<'a> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        struct ExportSerializer<'a>(&'a str, ComponentExternalKind);
-        impl<'a> Serialize for ExportSerializer<'a> {
-            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-            where
-                S: Serializer,
-            {
-                let mut map = serializer.serialize_map(Some(2))?;
-                map.serialize_entry("name", self.0)?;
-                map.serialize_entry(
-                    "kind",
-                    match self.1 {
-                        ComponentExternalKind::Module => "module",
-                        ComponentExternalKind::Func => "function",
-                        ComponentExternalKind::Value => "value",
-                        ComponentExternalKind::Type => "type",
-                        ComponentExternalKind::Instance => "instance",
-                        ComponentExternalKind::Component => "component",
-                    },
-                )?;
-                map.end()
-            }
-        }
-
-        let exports = self.0.exports();
-        let mut seq = serializer.serialize_seq(Some(exports.len()))?;
-        for (_, name, kind, _) in self.0.exports() {
-            seq.serialize_element(&ExportSerializer(name, kind))?;
-        }
-
-        seq.end()
-    }
-}
-
-struct ComponentSerializer<'a>(ComponentId, &'a Component<'a>);
-
-impl Serialize for ComponentSerializer<'_> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut map = serializer.serialize_map(Some(5))?;
-        map.serialize_entry("id", &self.0 .0)?;
-        map.serialize_entry("name", self.1.name())?;
-        map.serialize_entry("imports", &ImportsSerializer(self.1))?;
-        map.serialize_entry("exports", &ExportsSerializer(self.1))?;
+        let component = graph.get_component(id).unwrap();
 
         let interfaces =
-            decode_component_interfaces(self.1.bytes()).map_err(serde::ser::Error::custom)?;
+            decode_component_interfaces(component.bytes()).map_err(|e| format!("{e:#}"))?;
 
-        if let Some(default) = &interfaces.default {
-            let mut printer = InterfacePrinter::default();
-            map.serialize_entry(
-                "interface",
-                printer
-                    .print(default)
-                    .map_err(serde::ser::Error::custom)?
-                    .trim(),
-            )?;
-        }
-        map.end()
+        Ok(Component {
+            id: id.0 as u32,
+            name: component.name().to_string(),
+            imports: component
+                .imports()
+                .map(|(_, name, ty)| Import {
+                    name: name.to_string(),
+                    kind: match ty {
+                        ComponentTypeRef::Module(_) => ItemKind::Module,
+                        ComponentTypeRef::Func(_) => ItemKind::Function,
+                        ComponentTypeRef::Value(_) => ItemKind::Value,
+                        ComponentTypeRef::Type(_, _) => ItemKind::Type,
+                        ComponentTypeRef::Instance(_) => ItemKind::Instance,
+                        ComponentTypeRef::Component(_) => ItemKind::Component,
+                    },
+                })
+                .collect(),
+            exports: component
+                .exports()
+                .map(|(_, name, kind, _)| Export {
+                    name: name.to_string(),
+                    kind: match kind {
+                        ComponentExternalKind::Module => ItemKind::Module,
+                        ComponentExternalKind::Func => ItemKind::Function,
+                        ComponentExternalKind::Value => ItemKind::Value,
+                        ComponentExternalKind::Type => ItemKind::Type,
+                        ComponentExternalKind::Instance => ItemKind::Instance,
+                        ComponentExternalKind::Component => ItemKind::Component,
+                    },
+                })
+                .collect(),
+            interface: interfaces
+                .default
+                .map(|i| {
+                    let mut printer = InterfacePrinter::default();
+                    printer.print(&i)
+                })
+                .transpose()
+                .map_err(|e| format!("{e:#}"))?,
+        })
+    }
+
+    fn instantiate_component(id: ComponentId) -> Result<InstanceId, String> {
+        GRAPH
+            .lock()
+            .unwrap()
+            .instantiate(id as usize)
+            .map(|id| id.0 as u32)
+            .map_err(|e| format!("{e:#}"))
+    }
+
+    fn connect_instances(
+        source: InstanceId,
+        source_export: Option<u32>,
+        target: InstanceId,
+        target_import: u32,
+    ) -> Result<(), String> {
+        GRAPH
+            .lock()
+            .unwrap()
+            .connect(
+                source as usize,
+                source_export.map(|e| e as usize),
+                target as usize,
+                target_import as usize,
+            )
+            .map_err(|e| format!("{e:#}"))
+    }
+
+    fn remove_component(id: ComponentId) {
+        GRAPH.lock().unwrap().remove_component(id as usize);
+    }
+
+    fn remove_instance(id: InstanceId) {
+        GRAPH.lock().unwrap().remove_instance(id as usize);
+    }
+
+    fn disconnect_instances(
+        source: InstanceId,
+        target: InstanceId,
+        target_import: u32,
+    ) -> Result<(), String> {
+        GRAPH
+            .lock()
+            .unwrap()
+            .disconnect(source as usize, target as usize, target_import as usize)
+            .map_err(|e| format!("{e:#}"))
+    }
+
+    fn print_graph() -> String {
+        format!("{:#?}", GRAPH.lock().unwrap())
+    }
+
+    fn encode_graph(options: EncodeOptions) -> Result<Vec<u8>, String> {
+        GRAPH
+            .lock()
+            .unwrap()
+            .encode(wasm_compose::graph::EncodeOptions {
+                define_components: options.define_components,
+                export: options
+                    .export
+                    .map(|i| wasm_compose::graph::InstanceId(i as usize)),
+                validate: options.validate,
+            })
+            .map_err(|e| format!("{e:#}"))
     }
 }
 
-#[wasm_bindgen(js_name = "addComponent")]
-pub fn add_component(name: String, bytes: Vec<u8>) -> Result<JsValue, JsValue> {
-    let component =
-        Component::from_bytes(name, bytes).map_err(|e| JsValue::from(format!("{e:#}")))?;
-
-    let mut graph = GRAPH.lock().unwrap();
-
-    let id = graph
-        .add_component(component)
-        .map_err(|e| JsValue::from(format!("{e:#}")))?;
-
-    ComponentSerializer(id, graph.get_component(id).unwrap())
-        .serialize(&serde_wasm_bindgen::Serializer::json_compatible())
-        .map_err(|e| JsValue::from(format!("{e:#}")))
-}
-
-#[wasm_bindgen(js_name = "instantiateComponent")]
-pub fn instantiate_component(id: usize) -> Result<usize, JsValue> {
-    GRAPH
-        .lock()
-        .unwrap()
-        .instantiate(id)
-        .map(|id| id.0)
-        .map_err(|e| JsValue::from(format!("{e:#}")))
-}
-
-#[wasm_bindgen(js_name = "connectInstances")]
-pub fn connect_instances(
-    source: usize,
-    source_export: Option<usize>,
-    target: usize,
-    target_import: usize,
-) -> Result<(), JsValue> {
-    GRAPH
-        .lock()
-        .unwrap()
-        .connect(source, source_export, target, target_import)
-        .map_err(|e| JsValue::from(format!("{e:#}")))
-}
-
-#[wasm_bindgen(js_name = "removeComponent")]
-pub fn remove_component(id: usize) {
-    GRAPH.lock().unwrap().remove_component(id)
-}
-
-#[wasm_bindgen(js_name = "removeInstance")]
-pub fn remove_instance(id: usize) {
-    GRAPH.lock().unwrap().remove_instance(id)
-}
-
-#[wasm_bindgen(js_name = "disconnectInstances")]
-pub fn disconnect_instances(
-    source: usize,
-    target: usize,
-    target_import: usize,
-) -> Result<(), JsValue> {
-    GRAPH
-        .lock()
-        .unwrap()
-        .disconnect(source, target, target_import)
-        .map_err(|e| JsValue::from(format!("{e:#}")))
-}
-
-#[wasm_bindgen(js_name = "printGraph")]
-pub fn print_graph() -> String {
-    format!("{:#?}", GRAPH.lock().unwrap())
-}
-
-#[wasm_bindgen(js_name = "encodeGraph")]
-pub fn encode_graph(define_components: bool, export: Option<usize>) -> Result<Vec<u8>, JsValue> {
-    GRAPH
-        .lock()
-        .unwrap()
-        .encode(EncodeOptions {
-            define_components,
-            export: export.map(Into::into),
-            validate: true,
-        })
-        .map_err(|e| JsValue::from(format!("{e:#}")))
-}
+bindings::export!(GraphComponent);

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -9,7 +9,6 @@ import ReactFlow, {
   ReactFlowProvider,
   BackgroundVariant,
 } from "react-flow-renderer";
-import init from "./graph";
 import { Component, Instance, useAppState } from "./state";
 import InstanceNode from "./nodes";
 import colors from "tailwindcss/colors";
@@ -161,5 +160,3 @@ const App = () => {
 };
 
 export default App;
-
-(async () => await init())();

--- a/src/dialogs.tsx
+++ b/src/dialogs.tsx
@@ -97,16 +97,12 @@ export const AddComponentDialog = ({
 
     const bytes = new Uint8Array(await file.arrayBuffer());
     try {
-      const component = addComponentToGraph(name, bytes);
+      const component = addComponentToGraph(name, bytes) as Component;
       component.color = selectedColor;
       component.description = description;
       onClose(component);
     } catch (e) {
-      if (e instanceof Error) {
-        throw e;
-      }
-
-      setFileError(e);
+      setFileError(e.payload);
     }
   };
 
@@ -423,7 +419,11 @@ export const DownloadComponentDialog = ({
     }
 
     try {
-      const bytes = encodeGraph(defineComponents, exportedInstance);
+      const bytes = encodeGraph({
+        defineComponents,
+        export: exportedInstance?.id,
+        validate: true,
+      });
 
       downloadFile(name, bytes);
 
@@ -436,14 +436,10 @@ export const DownloadComponentDialog = ({
 
       onClose(component);
     } catch (e) {
-      if (e instanceof Error) {
-        throw e;
-      }
-
       pushNotification({
         type: NotificationType.Error,
         title: "Download Failed",
-        message: e,
+        message: e.payload,
       });
 
       onClose(null);

--- a/src/nodes.tsx
+++ b/src/nodes.tsx
@@ -30,9 +30,9 @@ const InstanceNode = ({ data, selected }: InstanceNodeProps) => {
                   id="exported"
                   name="exported"
                   type="checkbox"
-                  checked={data.id == exportedInstance}
+                  checked={data.id == exportedInstance?.id}
                   onChange={(e) =>
-                    exportInstance(e.target.checked ? data.id : null)
+                    exportInstance(e.target.checked ? data : null)
                   }
                   className={`h-4 w-4 rounded border-${color}-300 text-${color}-500 focus:ring-0`}
                 />


### PR DESCRIPTION
This PR replaces the graph WebAssembly module (and wasm-bindgen) with a WebAssembly component (with wit-bindgen).

The component code gets a well-defined interface and doesn't have to use serde to marshal the complex types to the JavaScript.

It also allows the JavaScript to directly use the generated bindings rather than having to define the types on both sides.