### PR TITLE
fix: update to latest wit and tools

### DIFF
--- a/crates/graph/world.wit
+++ b/crates/graph/world.wit
@@ -1,4 +1,6 @@
-default world graph {
+package component:graph
+
+world graph {
     // TODO: once jsct supports type world items, remove the interface export
     export graph: interface {
         /// Represents a kind of import or export in a WebAssembly component.


### PR DESCRIPTION
This doesn't work yet while jco is on an older version of
the component model ABI.

This change updates the graph component to the latest
changes on main.